### PR TITLE
Add image component, various updates

### DIFF
--- a/src/components/PageList.js
+++ b/src/components/PageList.js
@@ -22,6 +22,7 @@ const PageList = () => (
       <li><Link to="/components/#forms">Forms</Link></li>
       <li><Link to="/components/#highlight">Highlight</Link></li>
       <li><Link to="/components/#icon">Icon</Link></li>
+      <li><Link to="/components/#image">Image</Link></li>
       <li><Link to="/components/#row">Row</Link></li>
       <li><Link to="/components/#shelf">Shelf</Link></li>
       <li><Link to="/components/#site-header">Site Header</Link></li>

--- a/src/items/action-drawer.js
+++ b/src/items/action-drawer.js
@@ -14,6 +14,7 @@ const Item = () => (
       &lt;ActionDrawer<br />
         &nbsp;&nbsp;&nbsp;message [string]<br />
         &nbsp;&nbsp;&nbsp;messageStyle [style object]<br />
+        &nbsp;&nbsp;&nbsp;barStyles [style object]<br />
         &nbsp;&nbsp;&nbsp;buttonText [string]<br />
         &nbsp;&nbsp;&nbsp;buttonOnPress [function]<br />
       /&gt;

--- a/src/items/button.js
+++ b/src/items/button.js
@@ -31,11 +31,13 @@ const Item = () => (
       &lt;Button<br />
         &nbsp;&nbsp;&nbsp;[secondary | compact | minor | plain | system | disabled]<br />
         &nbsp;&nbsp;&nbsp;onPress [function]<br />
+        &nbsp;&nbsp;&nbsp;onLongPress [function]<br />
         &nbsp;&nbsp;&nbsp;hitSlop [object]<br />
         &nbsp;&nbsp;&nbsp;text [string]<br />
         &nbsp;&nbsp;&nbsp;textStyle [style object]<br />
         &nbsp;&nbsp;&nbsp;bgColor [string]<br />
         &nbsp;&nbsp;&nbsp;style [style object]<br />
+        &nbsp;&nbsp;&nbsp;buttonInnerStyle [style object]<br />
         &nbsp;&nbsp;&nbsp;icon [string]<br />
         &nbsp;&nbsp;&nbsp;iconType [string]<br />
         &nbsp;&nbsp;&nbsp;iconStyle [style object]<br />

--- a/src/items/card.js
+++ b/src/items/card.js
@@ -9,7 +9,7 @@ const Item = () => (
   <section id="card">
     <h2>Card</h2>
     <p>A card always has an image and title; it can optionally include a subtitle, description, and/or badge (or button). If the card includes a description and a badge, the badge should be displayed below the description; otherwise, it should be displayed at the right.</p>
-    <p><em>Only the rudimentary card has been implemented. The second and third example card styles shown here are not currently in use.</em></p>
+    <p><em>The second example card style shown here are not currently in use. Add the secondary prop to your card to display the small image card.</em></p>
 
     <p><img src={card} alt="Simple card" width="335" /></p>
     <p><img src={cardCollage} alt="Collage card" width="335" /></p>
@@ -17,6 +17,7 @@ const Item = () => (
 
     <code>
       &lt;Card<br />
+        &nbsp;&nbsp;&nbsp;secondary<br />
         &nbsp;&nbsp;&nbsp;onPress [function]<br />
         &nbsp;&nbsp;&nbsp;style [style object]<br />
         &nbsp;&nbsp;&nbsp;title [string]<br />

--- a/src/items/card.js
+++ b/src/items/card.js
@@ -9,7 +9,7 @@ const Item = () => (
   <section id="card">
     <h2>Card</h2>
     <p>A card always has an image and title; it can optionally include a subtitle, description, and/or badge (or button). If the card includes a description and a badge, the badge should be displayed below the description; otherwise, it should be displayed at the right.</p>
-    <p><em>The second example card style shown here are not currently in use. Add the secondary prop to your card to display the small image card.</em></p>
+    <p><em>The second example card style shown here is not currently in use. Add the secondary prop to your card to display the small image card.</em></p>
 
     <p><img src={card} alt="Simple card" width="335" /></p>
     <p><img src={cardCollage} alt="Collage card" width="335" /></p>

--- a/src/items/icon.js
+++ b/src/items/icon.js
@@ -6,8 +6,8 @@ const Item = () => (
     <p>This is a helper component that provides unified access to both our custom icons and a few libraries built into react-native-vector-icons.</p>
     <p>If no icon type is passed to the component, it's assumed that we're using one of our custom icons.</p>
     <code>
-      &lt;Icon<br />
-        &nbsp;&nbsp;&nbsp;type [string: FontAwesome, Entypo, Ionicons, Material]<br />
+      &lt;DoxyIcon<br />
+        &nbsp;&nbsp;&nbsp;type [string: FontAwesome, Entypo, EvilIcons, Feather, Ionicons, Material]<br />
         &nbsp;&nbsp;&nbsp;name [string]<br />
         &nbsp;&nbsp;&nbsp;style [style object]<br />
       /&gt;

--- a/src/items/image.js
+++ b/src/items/image.js
@@ -1,0 +1,16 @@
+import React from 'react'
+
+const Item = () => (
+  <section id="image">
+    <h2>Image</h2>
+    <p>DoxyImage is a wrapper over the FastImage component. It adds a spinner that is displayed before an image is loaded into the FastImage cache.</p>
+    <code>
+      &lt;DoxyImage<br />
+        &nbsp;&nbsp;&nbsp;resizeMode [string: cover, contain]<br />
+        &nbsp;&nbsp;&nbsp;source [string]<br />
+      /&gt;
+    </code>
+  </section>
+)
+
+export default Item

--- a/src/items/row.js
+++ b/src/items/row.js
@@ -19,12 +19,14 @@ const Item = () => (
         &nbsp;&nbsp;&nbsp;title [string]<br />
         &nbsp;&nbsp;&nbsp;buttonText [string]<br />
         &nbsp;&nbsp;&nbsp;onPress [function]<br />
+        &nbsp;&nbsp;&nbsp;hitSlop [object]<br />
       &gt;<br />
         &nbsp;&nbsp;&nbsp;&lt;Row<br />
           &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;onPress [function]<br />
           &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;hitSlop [object]<br />
           &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;style [style object]<br />
           &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;title [string]<br />
+          &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;titleRight [component]<br />
           &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;subtitle [string]<br />
           &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;description [string]<br />
           &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;imageSize [number]<br />

--- a/src/items/shelf.js
+++ b/src/items/shelf.js
@@ -11,6 +11,7 @@ const Item = () => (
       &lt;Shelf<br />
         &nbsp;&nbsp;&nbsp;style [style object]<br />
         &nbsp;&nbsp;&nbsp;containerStyle [style object]<br />
+        &nbsp;&nbsp;&nbsp;contentContainerStyle [style object]<br />
       &gt;<br />
         &nbsp;&nbsp;&nbsp;&lt;ShelfItem<br />
           &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[multiline]<br />

--- a/src/pages/components.js
+++ b/src/pages/components.js
@@ -10,6 +10,7 @@ import ExpandingText from '../items/expanding-text'
 import Forms from '../items/forms'
 import Highlight from '../items/highlight'
 import Icon from '../items/icon'
+import Image from '../items/image'
 import Row from '../items/row'
 import Shelf from '../items/shelf'
 import SiteHeader from '../items/site-header'
@@ -30,6 +31,7 @@ const IndexPage = () => (
     <Forms />
     <Highlight />
     <Icon />
+    <Image />
     <Row />
     <Shelf />
     <SiteHeader />

--- a/yarn.lock
+++ b/yarn.lock
@@ -1738,6 +1738,15 @@ cliui@^3.2.0:
     strip-ansi "^3.0.1"
     wrap-ansi "^2.0.0"
 
+cliui@^4.0.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/cliui/-/cliui-4.1.0.tgz#348422dbe82d800b3022eef4f6ac10bf2e4d1b49"
+  integrity sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==
+  dependencies:
+    string-width "^2.1.1"
+    strip-ansi "^4.0.0"
+    wrap-ansi "^2.0.0"
+
 clone@2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/clone/-/clone-2.1.1.tgz#d217d1e961118e3ac9a4b8bba3285553bf647cdb"
@@ -2540,6 +2549,11 @@ entities@^1.1.1, entities@~1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/entities/-/entities-1.1.1.tgz#6e5c2d0a5621b5dadaecef80b90edfb5cd7772f0"
 
+envinfo@^5.8.1:
+  version "5.12.1"
+  resolved "https://registry.yarnpkg.com/envinfo/-/envinfo-5.12.1.tgz#83068c33e0972eb657d6bc69a6df30badefb46ef"
+  integrity sha512-pwdo0/G3CIkQ0y6PCXq4RdkvId2elvtPCJMG0konqlrfkWQbf1DWeH9K2b/cvu2YgGvPPTOnonZxXM1gikFu1w==
+
 eol@^0.8.1:
   version "0.8.1"
   resolved "https://registry.yarnpkg.com/eol/-/eol-0.8.1.tgz#defc3224990c7eca73bb34461a56cf9dc24761d0"
@@ -2970,7 +2984,7 @@ find-up@^1.0.0:
     path-exists "^2.0.0"
     pinkie-promise "^2.0.0"
 
-find-up@^2.0.0:
+find-up@^2.0.0, find-up@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-2.1.0.tgz#45d1b7e506c717ddd482775a2b77920a3c0c57a7"
   dependencies:
@@ -3167,6 +3181,30 @@ gatsby-cli@^1.1.50:
     stack-trace "^0.0.10"
     update-notifier "^2.3.0"
     yargs "^8.0.2"
+    yurnalist "^0.2.1"
+
+gatsby-cli@^1.1.58:
+  version "1.1.58"
+  resolved "https://registry.yarnpkg.com/gatsby-cli/-/gatsby-cli-1.1.58.tgz#5dda246b9877ab925f6a512f723c20557af22d57"
+  integrity sha1-Xdoka5h3q5JfalEvcjwgVXryLVc=
+  dependencies:
+    babel-code-frame "^6.26.0"
+    babel-runtime "^6.26.0"
+    bluebird "^3.5.0"
+    common-tags "^1.4.0"
+    convert-hrtime "^2.0.0"
+    core-js "^2.5.0"
+    envinfo "^5.8.1"
+    execa "^0.8.0"
+    fs-extra "^4.0.1"
+    hosted-git-info "^2.5.0"
+    lodash "^4.17.4"
+    pretty-error "^2.1.1"
+    resolve-cwd "^2.0.0"
+    source-map "^0.5.7"
+    stack-trace "^0.0.10"
+    update-notifier "^2.3.0"
+    yargs "^11.1.0"
     yurnalist "^0.2.1"
 
 gatsby-link@^1.6.39, gatsby-link@^1.6.40:
@@ -8228,6 +8266,13 @@ yargs-parser@^7.0.0:
   dependencies:
     camelcase "^4.1.0"
 
+yargs-parser@^9.0.2:
+  version "9.0.2"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-9.0.2.tgz#9ccf6a43460fe4ed40a9bb68f48d43b8a68cc077"
+  integrity sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=
+  dependencies:
+    camelcase "^4.1.0"
+
 yargs@4.7.1:
   version "4.7.1"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-4.7.1.tgz#e60432658a3387ff269c028eacde4a512e438dff"
@@ -8245,6 +8290,24 @@ yargs@4.7.1:
     window-size "^0.2.0"
     y18n "^3.2.1"
     yargs-parser "^2.4.0"
+
+yargs@^11.1.0:
+  version "11.1.0"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-11.1.0.tgz#90b869934ed6e871115ea2ff58b03f4724ed2d77"
+  integrity sha512-NwW69J42EsCSanF8kyn5upxvjp5ds+t3+udGBeTbFnERA+lF541DDpMawzo4z6W/QrzNM18D+BPMiOBibnFV5A==
+  dependencies:
+    cliui "^4.0.0"
+    decamelize "^1.1.1"
+    find-up "^2.1.0"
+    get-caller-file "^1.0.1"
+    os-locale "^2.0.0"
+    require-directory "^2.1.1"
+    require-main-filename "^1.0.1"
+    set-blocking "^2.0.0"
+    string-width "^2.0.0"
+    which-module "^2.0.0"
+    y18n "^3.2.1"
+    yargs-parser "^9.0.2"
 
 yargs@^8.0.2:
   version "8.0.2"


### PR DESCRIPTION
- We’ve added a `DoxyImage` component that wraps a loading spinner and the `FastImage` caching library
- `ActionDrawer` gained a `barStyles` prop for custom styling of the action bar background
- `DoxyButton` gained `onLongPress` and `buttonInnerStyle` props
- A small `Card` variant was implemented for `My Groups`
- `EvilIcons` and `Feather` icon sets are now available in `DoxyIcon`
- `Shelf` gained a `contentContainerStyle` so the scroll area padding can be adjusted
- The `Row` component gained a `hitSlop` prop and a `titleRight` prop so a badge could be delivered to the group member list to denote group leaders:

<img width="362" alt="image" src="https://user-images.githubusercontent.com/419297/55116236-4690c300-50ac-11e9-9c54-9c91b97593d9.png">

